### PR TITLE
msi_status positional arguments in evaluate_sample.py

### DIFF
--- a/main/evaluate_sample.py
+++ b/main/evaluate_sample.py
@@ -150,9 +150,10 @@ def nparray_stats(nparray, confidence):
                 np.min(nparray),
                 np.max(nparray),
                 mean,
-                max(0.0, mean - moe),
-                min(1.0, mean + moe),
-                msi_status(mean),
+                max(0.0, mean - moe),  # lci
+                min(1.0, mean + moe),  # uci
+#                msi_status(mean),
+                 msi_status(min(1.0, mean + moe), max(0.0, mean - moe))
             ],
         )
     )


### PR DESCRIPTION
A change from `mean` to `[lci, uci]` likely not reflected in the call to `msi_status(...)`